### PR TITLE
oci: add trailing newline to nsswitch.conf

### DIFF
--- a/oci/entries.nix
+++ b/oci/entries.nix
@@ -115,7 +115,10 @@ rec {
   )) // (lib.optionalAttrs hosts {
     "/etc/nsswitch.conf" = {
       type = "file";
-      text = "hosts: files dns";
+      # the trailing newline is critical
+      text = ''
+        hosts: files dns
+      '';
     };
   }) // (lib.optionalAttrs tmp {
     "/tmp" = {


### PR DESCRIPTION
A unix text contains a sequence of lines, and lines must be terminated
by linefeed characters.