### PR TITLE
oci: compress layers with gzip

### DIFF
--- a/oci/hash-layer.py
+++ b/oci/hash-layer.py
@@ -1,13 +1,28 @@
 #!/usr/bin/env python3
 
+from enum import Enum
+from collections import namedtuple
 import hashlib
 import json
 import os
 import sys
 
+
+class Format(namedtuple('Format', ['extension', 'type_suffix']), Enum):
+    ZSTD = ('.zst', '+zstd')
+    GZIP = ('.gz', '+gzip')
+    TAR = ('', '')
+
+    @classmethod
+    def parse(cls, name):
+        return cls[name.upper()]
+
+
 if __name__ == '__main__':
     out_dir = sys.argv[1]
-    out_path = os.path.join(out_dir, 'layer.tar')
+    fmt = Format.parse(sys.argv[2] or 'tar')
+
+    out_path = os.path.join(out_dir, f"layer.tar{fmt.extension}")
     metadata_path = os.path.join(out_dir, 'metadata.json')
     blobs_path = os.path.join(out_dir, 'blobs', 'sha256')
 
@@ -23,9 +38,10 @@ if __name__ == '__main__':
             read_bytes += len(buf)
     sha256 = m.hexdigest()
 
-    metadata = dict(mediaType='application/vnd.oci.image.layer.v1.tar',
-                    size=size,
-                    digest="sha256:{}".format(sha256))
+    metadata = dict(
+        mediaType=f"application/vnd.oci.image.layer.v1.tar{fmt.type_suffix}",
+        size=size,
+        digest="sha256:{}".format(sha256))
 
     with open(metadata_path, 'w') as f:
         f.write(json.dumps(metadata))


### PR DESCRIPTION
We can also compress with zstd but the default EKS AMI doesn't seem to support it yet as it's still on containerd 1.4.x and 1.5 is needed to get zstd images.

Note that this does not save money on storage as ECR automatically gzip compresses the layers if uncompressed. It would save some money if we could use zstd though. This mostly just saves `/nix/store` space and time uploading as we can transfer less data.