### PR TITLE
Enable multi-arch build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,6 @@
         inherit (pkgs) callPackage;
       in
       {
-        # this does lock us to a different nixpkgs version for the docker build
-        # steps but it ensures the API is what we expect
         utils.docker = callPackage ./docker.nix {};
         utils.oci = callPackage ./oci {};
       }


### PR DESCRIPTION
this PR modified the output scheme to allow multi-arch builds, but it's not backward compatible.
changes:
```
outputs.lib.docker => outputs.util.${system}.docker
```
affected projects:

- [x] https://github.com/iknow/ecr-k8s-auth/pull/2
- [x] https://github.com/iknow/configmap-gc/pull/2
- [x] https://github.com/iknow/slack-hubot/pull/9
- [x] https://github.com/iknow/kube-secret-backup/pull/2
