### PR TITLE
sandbox: tolerate absent TMPDIR, use conditional params

### DIFF
--- a/sandbox/darwin/common.sb
+++ b/sandbox/darwin/common.sb
@@ -76,5 +76,5 @@
 (allow file-read* (home-subpath "/Library/Caches/com.dmm.eikaiwa.EikaiwaDeveloper"))
 
 ;; If a state directory is defined, full access is granted to that directory
-(when (< 0 (string-length (param "STATE_DIR")))
+(when (param "STATE_DIR")
   (allow file* (subpath (param "STATE_DIR"))))

--- a/sandbox/darwin/wrapper.sh
+++ b/sandbox/darwin/wrapper.sh
@@ -17,14 +17,29 @@ fi
 # to also allow Chrome's sandbox.
 export EIKAIWA_SANDBOX_ACTIVE=true
 
+declare -a optional_defines
+
+# TMPDIR is removed by `nix shell`
+if [ -n "${TMPDIR:+set}" ]; then
+  optional_defines+=("-D" "TMPDIR=$TMPDIR")
+fi
+
+if [ -n "$TTY" ]; then
+  optional_defines+=("-D" "TTY=$TTY")
+fi
+
+state_dir="@state_dir@"
+
+if [ -n "$state_dir" ]; then
+  optional_defines+=("-D" "STATE_DIR=$state_dir")
+fi
+
 exec /usr/bin/sandbox-exec \
   -f "@profile@" \
-  -D "TTY=$TTY" \
   -D "HOME=$HOME" \
   -D "NIX_STORE=@store_dir@" \
   -D "SOURCE_ROOT=@source_root@" \
-  -D "TMPDIR=$TMPDIR" \
   -D "MACOS_TMPDIR=$(@get_tmpdir@)" \
-  -D "STATE_DIR=@state_dir@" \
+  "${optional_defines[@]}" \
   "@command@" \
   "$@"


### PR DESCRIPTION
Fixes:

```
❯ PORT=5432 nix shell -f . services.environment -c start-postgresql
/nix/store/bd73ng2lr9l60vb660md23sg0010vs06-sandboxed-postgresql-and-plugins-17.5/bin/postgres: line 20: TMPDIR: unbound variable
```

Which is empirically caused by `TMPDIR` being _removed_ from the environment by `nix shell`.


Previously there was an inconsistent mix of `(when (param "X") ...)` and `(when (< 0 (string-length (param "X"))) ...)`. Now all parameters are checked externally and can be checked by the former.