### PR TITLE
sandbox: use runtime shell for wrapper

### DIFF
--- a/sandbox/darwin/default.nix
+++ b/sandbox/darwin/default.nix
@@ -40,6 +40,7 @@ let
         local wrapper=$out/bin/$(basename "$1")
 
         substitute ${./wrapper.sh} "$wrapper" \
+          --subst-var-by "runtimeShell" "${pkgs.runtimeShell}" \
           --subst-var-by "profile" "${composedProfile}" \
           --subst-var-by "command" "$1" \
           --subst-var-by "store_dir" "${builtins.storeDir}" \

--- a/sandbox/darwin/wrapper.sh
+++ b/sandbox/darwin/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!@runtimeShell@
 
 set -euo pipefail
 


### PR DESCRIPTION
macOS built-in bash is old and has a bug where accessing `optional_defines[@]` will error if the array is empty.